### PR TITLE
support for systems with no std::locale named "C"

### DIFF
--- a/assimp2json/json_exporter.cpp
+++ b/assimp2json/json_exporter.cpp
@@ -62,7 +62,11 @@ public:
 		, flags(flags)
 	{
 		// make sure that all formatting happens using the standard, C locale and not the user's current locale
-		buff.imbue( std::locale("C") );
+		try {
+			buff.imbue( std::locale("C") );
+		}
+		catch(...)
+		{}
 	}
 
 	~JSONWriter()


### PR DESCRIPTION
constructor discussion for std::locale here: http://en.cppreference.com/w/cpp/locale/locale/locale discusses the case where a system may not have a locale of the given `std_name`, and the ctor will throw an exception if asked to construct a locale with an std_name that does not match any available.  Google's Native Client environment is a system with no locale named "C".  This change simply protects from that case and ignores the attempt to reset the std::stringstream
